### PR TITLE
Fix issue detecting dropdown types

### DIFF
--- a/src/ReactAddToCalendar.js
+++ b/src/ReactAddToCalendar.js
@@ -59,12 +59,12 @@ export default class ReactAddToCalendar extends React.Component {
         let self = this;
 
         let items = this.props.listItems.map((listItem) => {
-            let currentItem = Object.keys(listItem);
+            let currentItem = Object.keys(listItem)[0];
             let currentLabel = listItem[currentItem];
 
             let icon = null;
             if (self.props.displayItemIcons) {
-                let currentIcon = (currentItem[0] === 'outlook') ? 'windows' : currentItem;
+                let currentIcon = (currentItem === 'outlook') ? 'windows' : currentItem;
                 icon = <i className={'fa fa-' + currentIcon}/>;
             }
 


### PR DESCRIPTION
In the current code, what gets sent to `helpers.buildUrl` is an array of 1 item (the keys of the current list item) when it should be a string - the one (any only) key.

The effect this has at the moment is that all links are downloading as .ics files, and the google and yahoo are not working as they should. With this fix, they are now working for me. Hopefully you can merge this asap :)